### PR TITLE
change expressability to expressiveness

### DIFF
--- a/src/dictionary.ts
+++ b/src/dictionary.ts
@@ -752,7 +752,7 @@ export const en_dk : Lexeme[] = [
     keywords: ["complexity theory", "formal methods"]
   },
   {
-    word: "expressability",
+    word: "expressiveness",
     type: "sb.",
     translations: ["udtrykskraft, -en, -er, -erne"],
     keywords: ["complexity theory", "formal methods"]


### PR DESCRIPTION
[Expressibility](https://en.wiktionary.org/wiki/expressibility) is the ability to _be_ expressed, whereas [expressiveness](https://en.wikipedia.org/wiki/Expressive_power_(computer_science)) (expressivity, expressive power) is the ability to express. I think the latter corresponds better to _udtrykskraft_.