### PR TITLE
fix address spelling

### DIFF
--- a/src/dictionary.ts
+++ b/src/dictionary.ts
@@ -1281,7 +1281,7 @@ export const en_dk : Lexeme[] = [
     keywords: ["greek alphabet"]
   },
   {
-    word: "open adressing",
+    word: "open addressing",
     type: "sb.",
     translations: ["åben adressering, -en, -er, -erne"],
     keywords: ["algorithmics", "hashing"]


### PR DESCRIPTION
https://en.wiktionary.org/wiki/adress: "Misspelling of address."